### PR TITLE
sendCommand instead of send_command

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -288,7 +288,7 @@ Client.prototype.createConnection = function() {
           var cb = client.pongs.shift()
           if (cb) cb();
         } else if (m = PING.exec(client.inbound)) {
-          this.send_command(PONG_RESPONSE);
+          client.sendCommand(PONG_RESPONSE);
         } else if (m = INFO.exec(client.inbound)) {
           // Nothing for now..
         } else {


### PR DESCRIPTION
This replace the `this` keyword for the `client` var inside of a callback and use the right name for the `sendCommand` method.

I didn't know if I should have updated the version number.
