### PR TITLE
Preparing for 2.2.0 release

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -288,6 +288,7 @@ export interface PullOptions {
 }
 export interface PubAck {
     stream: string;
+    domain?: string;
     seq: number;
     duplicate: boolean;
     ack(): void;
@@ -355,6 +356,7 @@ export interface ConsumerOptsBuilder {
     durable(name: string): void;
     deliverAll(): void;
     deliverLast(): void;
+    deliverLastPerSubject(): void;
     deliverNew(): void;
     startSequence(seq: number): void;
     startTime(time: Date | Nanos): void;
@@ -408,6 +410,8 @@ export interface JsMsg {
     ackAck(): Promise<boolean>;
 }
 export interface DeliveryInfo {
+    domain: string;
+    account_hash?: string;
     stream: string;
     consumer: string;
     redeliveryCount: number;
@@ -517,7 +521,8 @@ export declare enum DeliverPolicy {
     Last = "last",
     New = "new",
     StartSequence = "by_start_sequence",
-    StartTime = "by_start_time"
+    StartTime = "by_start_time",
+    LastPerSubject = "last_per_subject"
 }
 export declare enum AckPolicy {
     None = "none",
@@ -591,17 +596,18 @@ export interface StreamMsgResponse extends ApiResponse {
         time: string;
     };
 }
-export interface SequencePair {
+export interface SequenceInfo {
     "consumer_seq": number;
     "stream_seq": number;
+    "last_active": Nanos;
 }
 export interface ConsumerInfo {
     "stream_name": string;
     name: string;
     created: number;
     config: ConsumerConfig;
-    delivered: SequencePair;
-    "ack_floor": SequencePair;
+    delivered: SequenceInfo;
+    "ack_floor": SequenceInfo;
     "num_ack_pending": number;
     "num_redelivered": number;
     "num_waiting": number;
@@ -653,6 +659,7 @@ export interface ConsumerConfig {
     name: string;
     "durable_name"?: string;
     "deliver_subject"?: string;
+    "deliver_group"?: string;
     "deliver_policy": DeliverPolicy;
     "opt_start_seq"?: number;
     "opt_start_time"?: string;
@@ -667,6 +674,7 @@ export interface ConsumerConfig {
     "max_ack_pending"?: number;
     "idle_heartbeat"?: Nanos;
     "flow_control"?: boolean;
+    description?: string;
 }
 export interface Consumer {
     "stream_name": string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "2.1.1-1",
+  "version": "2.2.0",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -41,7 +41,7 @@
     "build": "tsc",
     "cjs": "deno run --allow-all bin/cjs-fix-imports.ts -o nats-base-client/ ./.deps/nats.deno/nats-base-client/",
     "clean": "shx rm -Rf ./lib/* ./nats-base-client ./.deps",
-    "clone-nbc": "shx mkdir -p ./.deps && cd ./.deps && git clone --branch v1.1.0 https://github.com/nats-io/nats.deno.git",
+    "clone-nbc": "shx mkdir -p ./.deps && cd ./.deps && git clone --branch v1.2.0 https://github.com/nats-io/nats.deno.git",
     "fmt": "deno fmt ./src/ ./examples/ ./test/",
     "prepack": "npm run clone-nbc && npm run cjs && npm run check-package && npm run build",
     "ava": "nyc ava --verbose -T 60000",

--- a/src/node_transport.ts
+++ b/src/node_transport.ts
@@ -33,7 +33,7 @@ import { connect as tlsConnect, TlsOptions, TLSSocket } from "tls";
 const { resolve } = require("path");
 const { readFile, existsSync } = require("fs");
 
-const VERSION = "2.1.1-1";
+const VERSION = "2.2.0";
 const LANG = "nats.js";
 
 export class NodeTransport implements Transport {

--- a/test/jetstream.js
+++ b/test/jetstream.js
@@ -84,7 +84,7 @@ test("jetstream - jsm", async (t) => {
   consumers = await jsm.consumers.list("stream").next();
   t.is(consumers.length, 0);
 
-  const sm = await jsm.streams.getMessage("stream", 2);
+  const sm = await jsm.streams.getMessage("stream", { seq: 2 });
   t.is(sm.seq, 2);
   t.truthy(sm.header);
   t.is(sm.header.get("xxx"), "a");


### PR DESCRIPTION
- [UPDATE] update nbc to 1.2.0
- [UPDATE] jetstreamManager.streams.getMessage(number) to use the correct api from nbc.
- [UPDATE] index.d.ts to include changes to `PubAck` (`domain`), `ConsumerOptsBuilder#deliverLastPerSubject()`,  `DeliveryInfo` (`domain` and `account_hash`), `DeliveryPolicy#LastPerSubject`, renamed ConsumerInfo#SequencePair to ConsumerInfo#SequenceInfo, `ConsumerConfig` (`deliver_group` and `description`),