### PR TITLE
[FIX] objectstore polyfill to built-in node library (#555)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "nats",
-  "version": "2.11.0",
+  "version": "2.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nats",
-      "version": "2.11.0",
+      "version": "2.12.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "nkeys.js": "1.0.5",
-        "web-streams-polyfill": "^3.2.1"
+        "nkeys.js": "1.0.5"
       },
       "devDependencies": {
         "@types/node": "^18.13.x",
@@ -3513,14 +3512,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/well-known-symbols": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
@@ -6170,11 +6161,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "well-known-symbols": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -40,7 +40,7 @@
     "build": "tsc",
     "cjs": "deno run --allow-all bin/cjs-fix-imports.ts -o nats-base-client/ ./.deps/nats.deno/nats-base-client/",
     "clean": "shx rm -Rf ./lib/* ./nats-base-client ./.deps",
-    "clone-nbc": "shx mkdir -p ./.deps && cd ./.deps && git clone --branch v1.12.0 https://github.com/nats-io/nats.deno.git",
+    "clone-nbc": "shx mkdir -p ./.deps && cd ./.deps && git clone --branch v1.12.1 https://github.com/nats-io/nats.deno.git",
     "fmt": "deno fmt ./src/ ./examples/ ./test/",
     "prepack": "npm run clone-nbc && npm run cjs && npm run check-package && npm run build",
     "ava": "nyc ava --verbose -T 60000",
@@ -57,8 +57,7 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "nkeys.js": "1.0.5",
-    "web-streams-polyfill": "^3.2.1"
+    "nkeys.js": "1.0.5"
   },
   "devDependencies": {
     "@types/node": "^18.13.x",

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -20,12 +20,21 @@ if (typeof TextEncoder === "undefined") {
 
 if (typeof globalThis.crypto === "undefined") {
   const c = require("crypto");
+  // this will patch to undefined if webcrypto is not available (node 14)
+  // views will toss if crypto is not available
   global.crypto = c.webcrypto;
 }
 
 if (typeof globalThis.ReadableStream === "undefined") {
-  const streams = require("web-streams-polyfill/ponyfill");
-  global.ReadableStream = streams.ReadableStream;
+  // @ts-ignore: node global
+  const chunks = process.versions.node.split(".");
+  const v = parseInt(chunks[0]);
+  if (v >= 16) {
+    // this won't mess up fetch
+    const streams = require("stream/web");
+    // views will toss if ReadableStream is not available
+    global.ReadableStream = streams.ReadableStream;
+  }
 }
 
 export { connect } from "./connect";

--- a/src/node_transport.ts
+++ b/src/node_transport.ts
@@ -34,7 +34,7 @@ const { resolve } = require("path");
 const { readFile, existsSync } = require("fs");
 const dns = require("dns");
 
-const VERSION = "2.12.0";
+const VERSION = "2.12.1";
 const LANG = "nats.js";
 
 export class NodeTransport implements Transport {

--- a/test/jetstream.js
+++ b/test/jetstream.js
@@ -376,9 +376,9 @@ async function fromReadableStream(
 }
 
 test("jetstream - os basics", async (t) => {
-  if (process.version.startsWith("v14.")) {
+  if (parseInt(process.versions.node.split(".")[0]) < 16) {
     t.log(
-      `node ${process.version} cannot run objectstore as webcrypto is not available`,
+      `node ${process.versions.node} cannot run objectstore as webcrypto and ReadableStream are not available`,
     );
     t.pass();
     return;


### PR DESCRIPTION
[FIX] changed "web-streams-polifill/ponyfill" to "stream/web" (built into node 16+) - this is required to support ReadableStream in ObjectStore and not create inconsistencies with fetch and other libraries. FIX #555