### PR TITLE
[FEAT] Bump Typescript target to Node 14 (ES2020)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ES2020",
     "module": "CommonJS",
     "outDir": "lib/",
     "moduleResolution": "node",


### PR DESCRIPTION
This change:

* Improves performance (native async/await is faster than `__awaiter`)
* Improves debugging (error stacktraces are preserved through `async/await`)
* Reduces bundle size a bit (no `var __awaiter` in generated code)

This should be a safe change, as Node 14 is already required.