### PR TITLE
Update version to 2.29.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nats",
-  "version": "2.29.1",
+  "version": "2.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nats",
-      "version": "2.29.1",
+      "version": "2.29.2",
       "license": "Apache-2.0",
       "dependencies": {
         "nkeys.js": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "2.29.1",
+  "version": "2.29.2",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -41,8 +41,8 @@
     "cjs-nbc": "deno run --allow-all ./bin/cjs-fix-imports.ts -o nats-base-client/ ./.deps/nats.deno/nats-base-client",
     "cjs-jetstream": "deno run --allow-all ./bin/cjs-fix-imports.ts -o jetstream/ ./.deps/nats.deno/jetstream/",
     "cjs": "npm run cjs-nbc && npm run cjs-jetstream",
-    "clean": "shx rm -Rf ./lib/* ./nats-base-client ./.deps",
-    "clone-nbc": "shx mkdir -p ./.deps && cd ./.deps && git clone --branch v1.29.1 https://github.com/nats-io/nats.deno.git",
+    "clean": "shx rm -Rf ./lib/* ./nats-base-client ./jetstream ./.deps",
+    "clone-nbc": "shx mkdir -p ./.deps && cd ./.deps && git clone --branch v1.29.2 https://github.com/nats-io/nats.deno.git",
     "fmt": "deno fmt ./src/ ./examples/ ./test/",
     "prepack": "npm run clone-nbc && npm run cjs && npm run check-package && npm run build",
     "ava": "nyc ava --verbose -T 60000",

--- a/src/node_transport.ts
+++ b/src/node_transport.ts
@@ -34,7 +34,7 @@ const { resolve } = require("path");
 const { readFile, existsSync } = require("fs");
 const dns = require("dns");
 
-const VERSION = "2.29.1";
+const VERSION = "2.29.2";
 const LANG = "nats.js";
 
 export class NodeTransport implements Transport {


### PR DESCRIPTION
Bump package version from 2.29.1 to 2.29.2 across all files to align with the updated release. Adjust script to clone the correct version of `nats.deno`.